### PR TITLE
OS independent path to uapublisher-config.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // IntelliSense verwenden, um herauszufinden, welche Attribute für das C#-Debuggen vorhanden sind
+            // Hover für die Beschreibung der vorhandenen Attribute verwenden
+            // Weitere Informationen finden Sie unter https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // Wenn Sie Zielframeworks geändert haben, stellen Sie sicher, dass Sie den Programmpfad aktualisieren.
+            "program": "${workspaceFolder}/build/bin/Debug/UaMqttPublisher/net6.0/UaMqttPublisher.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/UaMqttPublisher",
+            // Weitere Informationen zum Feld \"Konsole\" finden Sie unter https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "integratedTerminal",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/UA-IIoT-StarterKit.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/UA-IIoT-StarterKit.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/UA-IIoT-StarterKit.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/UaMqttPublisher/Program.cs
+++ b/UaMqttPublisher/Program.cs
@@ -40,7 +40,7 @@ try
         {
             "publish",
             "--config",
-            "config\\uapublisher-config.json",
+            Path.Combine(new string[] {"config", "uapublisher-config.json"}),
             "--broker",
             "HiveMQ",
             "--connection",


### PR DESCRIPTION
uapublisher-config.json cannot be found on macos because of the backlash.